### PR TITLE
Sync from latest for exmaple tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 # v2+ versions are using the Go module of go-restful v3+
 
 
+## v2.10.3
+
+- allow providing example value to a property via "example" tag (#124)
+- fix(enum): make enum field to be located in items object instead of in the root definition object (#123)
+
 ## v2.10.2
 
 - fix handle time.Time field #120 (#121)

--- a/definition_builder.go
+++ b/definition_builder.go
@@ -332,6 +332,13 @@ func (b definitionBuilder) buildArrayTypeProperty(field reflect.StructField, jso
 	}
 	isPrimitive := b.isPrimitiveType(itemType.Name(), itemType.Kind())
 	elemTypeName := b.getElementTypeName(modelName, jsonName, itemType)
+
+	// If enum exists, move the enum definition from the `type: "array"` definition to `items`.
+	if prop.Enum != nil {
+		prop.Items.Schema.Enum = prop.Enum
+		prop.Enum = nil
+	}
+
 	if isPrimitive {
 		mapped := b.jsonSchemaType(elemTypeName, itemType.Kind())
 		itemSchema.Type = []string{mapped}

--- a/definition_builder.go
+++ b/definition_builder.go
@@ -205,18 +205,27 @@ func (b definitionBuilder) buildProperty(field reflect.StructField, model *spec.
 	}
 
 	// not a primitive
+	// Since the `prop` variable in each of the cases below is a new reference, we need to re-set the `Example` field.
 	switch {
 	case fieldKind == reflect.Struct:
 		jsonName, prop := b.buildStructTypeProperty(field, jsonName, model)
+		setExample(&prop, field)
+
 		return jsonName, modelDescription, prop
 	case b.isSliceOrArrayType(fieldKind):
 		jsonName, prop := b.buildArrayTypeProperty(field, jsonName, modelName)
+		setExample(&prop, field)
+
 		return jsonName, modelDescription, prop
 	case fieldKind == reflect.Ptr:
 		jsonName, prop := b.buildPointerTypeProperty(field, jsonName, modelName)
+		setExample(&prop, field)
+
 		return jsonName, modelDescription, prop
 	case fieldKind == reflect.Map:
 		jsonName, prop := b.buildMapTypeProperty(field, jsonName, modelName)
+		setExample(&prop, field)
+
 		return jsonName, modelDescription, prop
 	}
 
@@ -229,6 +238,7 @@ func (b definitionBuilder) buildProperty(field reflect.StructField, model *spec.
 		prop.Ref = spec.MustCreateRef("#/definitions/" + nestedTypeName)
 		b.addModel(fieldType, nestedTypeName)
 	}
+
 	return jsonName, modelDescription, prop
 }
 

--- a/definition_builder_test.go
+++ b/definition_builder_test.go
@@ -3,6 +3,7 @@ package restfulspec
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -577,6 +578,21 @@ func TestTimeField(t *testing.T) {
 	sc := db.Definitions["restfulspec.timeHolder"]
 	pr := sc.Properties["when"]
 	if got, want := pr.Format, "date-time"; got != want {
+		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
+	}
+}
+
+type arrayofEnumsHolder struct {
+	Titles []string `json:"titles" enum:"EMPLOYEE|MANAGER"`
+}
+
+func TestArrayOfEnumsField(t *testing.T) {
+	db := definitionBuilder{Definitions: spec.Definitions{}, Config: Config{}}
+	db.addModelFrom(arrayofEnumsHolder{})
+	sc := db.Definitions["restfulspec.arrayofEnumsHolder"]
+	pr := sc.Properties["titles"]
+
+	if got, want := pr.Items.Schema.Enum, []interface{}{"EMPLOYEE", "MANAGER"}; !reflect.DeepEqual(got, want) {
 		t.Errorf("got [%v:%T] want [%v:%T]", got, got, want, want)
 	}
 }

--- a/property_ext.go
+++ b/property_ext.go
@@ -141,6 +141,12 @@ func setReadOnly(prop *spec.Schema, field reflect.StructField) {
 	}
 }
 
+func setExample(prop *spec.Schema, field reflect.StructField) {
+	if exampleTag := field.Tag.Get("example"); exampleTag != "" {
+		prop.Example = exampleTag
+	}
+}
+
 func setPropertyMetadata(prop *spec.Schema, field reflect.StructField) {
 	setDescription(prop, field)
 	setDefaultValue(prop, field)
@@ -155,4 +161,5 @@ func setPropertyMetadata(prop *spec.Schema, field reflect.StructField) {
 	setGoNameValue(prop, field)
 	setMinItems(prop, field)
 	setMaxItems(prop, field)
+	setExample(prop, field)
 }


### PR DESCRIPTION
 cherry-pick:

  1. 26f870e — example tag support (property_ext.go + definition_builder.go)
  2. 2efeea4 — enum array fix (definition_builder.go) — bonus correctness fix